### PR TITLE
userHeader handling

### DIFF
--- a/src/banks.cc
+++ b/src/banks.cc
@@ -128,6 +128,95 @@ map<string, double> getHeaderBank(evioDOMTree& EDT, gBank bank, double verbosity
 	return thisBank;
 }
 
+vector<string> getUserHeaderBankNames(evioDOMTree& EDT, gBank bank, double verbosity)
+{
+  // Examine data to find out how many variables in userHeader bank and construct list of names
+
+  vector<string> names;
+  unsigned long sizeOfBank = 0;
+
+  evioDOMNodeListP thisBankNode = EDT.getNodeList(tagNumEquals(bank.idtag, 0));
+  
+  for(evioDOMNodeList::const_iterator iter=thisBankNode->begin(); iter!=thisBankNode->end(); iter++)
+    {
+      const evioDOMNodeP node = *iter;
+      if(node->isContainer())
+	{
+	  evioDOMNodeList *variablesNodes = node->getChildList();
+	  for(evioDOMNodeList::const_iterator cIter=variablesNodes->begin(); cIter!=variablesNodes->end(); cIter++)
+	    {
+	      const evioDOMNodeP variable = *cIter;
+	      unsigned vnum = variable->num;
+	      if (variable->isLeaf() && sizeOfBank < vnum)
+		{
+		  sizeOfBank = vnum;
+		}
+	    }
+	}
+    }
+
+  for (unsigned i = 0; i < sizeOfBank; ++i)
+    {
+      string tmp = "userVar" ;
+      if(i<9)        tmp +="00";
+      else if (i<99) tmp +="0";
+      
+      tmp += to_string(i+1);
+      names.push_back (tmp);
+    }
+
+  if (verbosity > 0)
+    {
+      cout << "getUserHeaderBankNames" << endl;
+      for (vector<string>::iterator it = names.begin(); it != names.end(); it++)
+	{
+	  cout << "  > " << (*it) << endl;
+	}
+      cout << endl;
+    }
+
+  return names;
+}
+
+map<string, double> getUserHeaderBank(evioDOMTree& EDT, gBank bank, vector<string> names, double verbosity)
+{
+	map<string, double> thisBank;
+	
+	evioDOMNodeListP thisBankNode = EDT.getNodeList(tagNumEquals(bank.idtag, 0));
+
+	for(evioDOMNodeList::const_iterator iter=thisBankNode->begin(); iter!=thisBankNode->end(); iter++)
+	{
+	  const evioDOMNodeP node = *iter;
+	  if(node->isContainer())
+	    {
+	      evioDOMNodeList *variablesNodes = node->getChildList();
+	      for(evioDOMNodeList::const_iterator cIter=variablesNodes->begin(); cIter!=variablesNodes->end(); cIter++)
+		{
+		  const evioDOMNodeP variable = *cIter;
+		  int vnum = variable->num;
+		  if (variable->isLeaf())
+		    {
+		      const vector<double> *vec = (*cIter)->getVector<double>();
+		      thisBank[names[vnum-1]] = (*vec)[0];				  
+		    }
+		}
+	    }
+	}
+	
+	if(verbosity > 0)
+	{
+		for(map<string, double>::iterator it = thisBank.begin(); it != thisBank.end(); it++)
+		{
+			cout << "  > " << it->first << ": " << it->second << endl;
+		}
+		cout << endl;
+	}
+	
+
+
+	return thisBank;
+}
+
 map<string, vector<hitOutput> > getRawIntDataBanks(evioDOMTree& EDT, vector<string> hitTypes, map<string, gBank> *banksMap, double verbosity)
 {
 	map<string, vector<hitOutput> > rawBanks;
@@ -445,27 +534,5 @@ Mevent::Mevent(evioDOMTree& EDT, vector<string> hitTypes, map<string, gBank> *ba
 	}
 	
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 

--- a/src/banks.h
+++ b/src/banks.h
@@ -19,6 +19,8 @@ gBank getBank(gBank bank, double verbosity);
 
 // normal banks are just containers of leafs
 map<string, double> getHeaderBank(evioDOMTree& EDT, gBank bank, double verbosity);
+vector<string> getUserHeaderBankNames(evioDOMTree& EDT, gBank bank, double verbosity);
+map<string, double> getUserHeaderBank(evioDOMTree& EDT, gBank bank, vector<string> names, double verbosity);
 
 // integrated raw and digitized banks
 vector<hitOutput> getRawIntDataBank(evioDOMTree& EDT, string hitType, map<string, gBank> *banksMap, double verbosity);


### PR DESCRIPTION
 It contains new versions of banks.h, banks.cc, and evio2root.cc.

New function getUserHeaderBankNames in banks.cc, to be called at first event, looks at the userHeader information in the evio file; it uses the largest node number found to establish how many variables to allow for and returns a vector of names for those variables: userVar001, userVar002, … .

New function getUserHeaderBank in banks.cc returns a map<string,double> of data found in the evioDOMTree indexed by the names generated by getUserHeaderBankNames.

evio2root.cc correctly sets up the userHeader tree, initially empty; on the first event it calls getUserHeaderBankNames and creates a branch for each userHeader variable name. Then on each event it calls getUserHeaderBank to get the data and fill the userHeader tree.

Note:

1. This assumes the number of entries in userHeader does not change from one event to another (or at least that the highest node number in the first event is the maximum node number ever seen).

2. In GEMC 2.3, two numbers in the first line of each Lund file entry (the number of particles and the beam polarization) were not added to the header, so there were 8 variables var1 through var8. In GEMC 2.8 every number in the first line is entered into a userHeader variable. So for instance the event weight would be userVar010, instead of var8