### PR TITLE
fix entry bug and use option B for bank file name as before

### DIFF
--- a/src/bank_options.cc
+++ b/src/bank_options.cc
@@ -63,8 +63,8 @@ void goptions::setGoptions()
 	
 	// IO
 	optMap["B"].args = "all";
-	optMap["B"].help = "Bank(s) to be published";
-	optMap["B"].name = "Bank(s) to be published";
+	optMap["B"].help = "User bank files with banks to be published";
+	optMap["B"].name = "User bank files with banks to be published";
 	optMap["B"].type = 1;
 	optMap["B"].ctgr = "io";
 
@@ -88,11 +88,11 @@ void goptions::setGoptions()
 	optMap["N"].ctgr = "io";
 	
 	// Max Number of events
-	optMap["SELECT_RAW_VARiABLES"].args  = "all";
-	optMap["SELECT_RAW_VARiABLES"].help = "True info variables to be written out, separated by colon.";
-	optMap["SELECT_RAW_VARiABLES"].name = "True info variables to be written out, separated by colon.";
-	optMap["SELECT_RAW_VARiABLES"].type = 1;
-	optMap["SELECT_RAW_VARiABLES"].ctgr = "io";
+	optMap["SELECT_RAW_VARIABLES"].args  = "all";
+	optMap["SELECT_RAW_VARIABLES"].help = "True info variables to be written out, separated by colon.";
+	optMap["SELECT_RAW_VARIABLES"].name = "True info variables to be written out, separated by colon.";
+	optMap["SELECT_RAW_VARIABLES"].type = 1;
+	optMap["SELECT_RAW_VARIABLES"].ctgr = "io";
 
 
 	// require raw and dgt to have the same number of entries

--- a/src/evio2root.cc
+++ b/src/evio2root.cc
@@ -53,22 +53,22 @@ int main(int argc, char **argv)
 		// list of banks
 		string banklist    = gemcOpt.optMap["B"].args ;
 
-		vector<string> userBankFileList    = getStringVectorFromStringWithDelimiter(banklist, " ");
-		vector<string> userBankList    ;
-		for(auto &bankFile: userBankFileList) {
-			string bank = bankFile.substr(bankFile.find_last_of("/") + 1);
-			userBankList.push_back(bank);
-		}
-
-		for(auto &bank: userBankList) {
-			cout << " Bank found: " << bank << endl;
-		}
+// 		vector<string> userBankFileList    = getStringVectorFromStringWithDelimiter(banklist, " ");
+// 		vector<string> userBankList    ;
+// 		for(auto &bankFile: userBankFileList) {
+// 			string bank = bankFile.substr(bankFile.find_last_of("/") + 1);
+// 			userBankList.push_back(bank);
+// 		}
+// 
+// 		for(auto &bank: userBankList) {
+// 			cout << " Bank found: " << bank << endl;
+// 		}
 
 		vector<string> userRawBankList = getStringVectorFromStringWithDelimiter(gemcOpt.optMap["R"].args, " ");
-
+		
 		// list of true info variables
 		bool writeAll = false;
-		vector<string> trueInfoVariables = getStringVectorFromStringWithDelimiter(gemcOpt.optMap["SELECT_RAW_VARiABLES"].args, ":") ;
+		vector<string> trueInfoVariables = getStringVectorFromStringWithDelimiter(gemcOpt.optMap["SELECT_RAW_VARIABLES"].args, ":") ;
 		if(find(trueInfoVariables.begin(), trueInfoVariables.end(), "all") != trueInfoVariables.end()) {
 			writeAll = true;
 		}
@@ -141,7 +141,7 @@ int main(int argc, char **argv)
 			if(thisBankName == "raws")       defineBank = false;
 			if(thisBankName == "psummary")   defineBank = false;
 
-			if(find(userBankList.begin(), userBankList.end(), thisBankName) == userBankList.end())   defineBank = false;
+// 			if(find(userBankList.begin(), userBankList.end(), thisBankName) == userBankList.end())   defineBank = false;
 
 			bool defineRawBank = true;
 			if(find(userRawBankList.begin(), userRawBankList.end(), thisBankName) == userRawBankList.end()) defineRawBank = false;
@@ -175,6 +175,8 @@ int main(int argc, char **argv)
 
 		}
 		
+				
+		
 		// now filling the banks
 		// ---------------------
 		
@@ -192,6 +194,7 @@ int main(int argc, char **argv)
 		
 		while(chan->read() && (evn++ <= MAXN || MAXN == 0)) {
 			evioDOMTree EDT(chan);
+			if (evn<-1) continue;			
 			
 			// read all defined banks
 			for(map<string, gBank>::iterator it = banksMap.begin(); it != banksMap.end(); it++) {
@@ -327,13 +330,12 @@ int main(int argc, char **argv)
 						}
 					}
 
-					rTrees[thisBankName].fill();
+					rTrees[thisBankName].filluser();
 
 
 				}
 			}
 		}
-
 		chan->close();
 		f->Write();
 		delete f;

--- a/src/rootTrees.cc
+++ b/src/rootTrees.cc
@@ -79,13 +79,23 @@ void rTree::fill()
 // does the right thing and add an empty entry
 // to the tree if nothing there.
 
-//	if(weGotSomething)
+	if(weGotSomething)
 		tree->Fill();
 		
 //	else
 //		fillVoid();
 }
 
+void rTree::filluser()
+{
+// commenting the condition out cause ROOT
+// does the right thing and add an empty entry
+// to the tree if nothing there.
+
+//  	if(weGotSomething){
+ 		tree->Fill();
+
+}
 
 void rTree::init()
 {

--- a/src/rootTrees.h
+++ b/src/rootTrees.h
@@ -38,6 +38,7 @@ class rTree
 		bool weGotSomething;
 		void init();
 		void fill();
+		void filluser();
 		void fillVoid();
 
 };


### PR DESCRIPTION
While a detector tree can have empty entries because there is no hits for those events, all root trees should have same number of entries and the entry index number is the same as sim event number
To achieve this, somehow "header userHeader generated ancestors" and all other banks need different root tree fill condition for evio 5.1 and root 6.18.04

B option need to point to a file name for user defined bank. 
all GEMC internally defined banks are converted by default, including "header userHeader generated ancestors flux allraws mirror counter chargeTime rf", only "psummary" is not converted for now

example
evio2root -INPUTF=out.evio -B="/group/solid/solid_github/JeffersonLab/solid_gemc/geometry/ec_segmented_moved/solid_PVDIS_ec_forwardangle /group/solid/solid_github/JeffersonLab/solid_gemc/geometry/gem/solid_PVDIS_gem /group/solid/solid_github/JeffersonLab/solid_gemc/geometry/lgc_moved/lg_cherenkov" -R="flux"





